### PR TITLE
Simplified AbstractTransformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ localization and mapping).
 
 The package provide two main pieces of functionality
 
-1. Primarily, an interface for defining `AbstractTransformation`s and applying
+1. Primarily, an interface for defining `Transformation`s and applying
    (`transform()`), inverting (`inv()`), composing (`∘` or `compose()`) and
    differentiating (`transform_deriv()` and `transform_deriv_params()`) them.
 
 2. A small set of built-in, composable, primitive transformations for
-   transforming 2D and 3D points (leveraging the *FixedSizeArrays* and
-   *Rotations* packages).
+   transforming 2D and 3D points (optionally leveraging the *FixedSizeArrays*
+   and *Rotations* packages).
 
 ### Quick start
 
@@ -66,16 +66,11 @@ rotation angle:
 
 ### The interface
 
-Transformations are derived from `AbstractTransformation{OutType, InType}`.
-`InType` is a (possibly abstract or union) type describing which inputs
-`transform()` will accept with the given transformation, and `OutType` describes
-the (possible range of) outputs given. These parameters allow for a level of
-safety, so that transformations are only applied to appropriate data types and
-to catch early-on any problems with composing or chaining transformations.
-
-As an example, we have `Translation{T} <: AbstractTransformation{FixedVector, FixedVector}`.
-A translation will expect data in the `FixedVector` format and will always return
-the same base type as given (of course, type promotion may occur for the element type itself).
+Transformations are derived from `Transformation`. As an example, we have
+`Translation{T} <: Transformation`. A translation will accept points in a
+variety of formats, such as `Vector`, `FixedVector`, `Tuple`, etc, and will try
+to return the same type as given (of course, type promotion may occur for the
+element type itself).
 
 Transformations can be reversed using `inv(trans)`. They can be chained
 together using the `∘` operator (`trans1 ∘ trans2`) or `compose` function (`compose(trans1, trans2)`).
@@ -97,22 +92,22 @@ techniques, and can be parameterized by *DualNumbers*' `DualNumber` or *ForwardD
 ### Built-in transformations
 
 A small number of 2D and 3D coordinate systems and transformations are included.
-We also have `IdentityTransform{InOutType}` and `ComposedTransformation{InType,OutType}`,
-which allows us to nest together arbitrary transformations to create a
-complex yet efficient transformation chain.
+We also have `IdentityTransform` and `ComposedTransformation`, which allows us
+to nest together arbitrary transformations to create a complex yet efficient
+transformation chain.
 
 #### Coordinate types
 
-The canonical Cartesian coordinate data types are any type which inherited from
-*FixedSizeArrays*' `FixedVector{2}` and `FixedVector{3}` in 2D and 3D,
-respectively. The concrete datatypes `Point` and `Vec` are provided by
-*FixedSizeArrays*, and here we tend to favor `Point` for output where it is not
-specified. (Of course, users may define their own transformations and types, as
-they wish).
+The package does not assume any specific coordinate types for Cartesian
+coordinates, and aims to accept any indexable container (such as `Vector`,
+`Tuple`, *FixedSizeArrays*' `FixedSizeVector{N}` or any other duck-typed vector).
+For speed, we recommend using a statically-sized container such as `Point{N}` or
+`Vec{N}` from *FixedSizeArrays*,  or even an `NTuple{N}`. However, it is
+attempted that the package will not change your data type.
 
-The `Polar(r, θ)` type is a 2D polar representation of a point, and similarly
-in 3D we have defined `Spherical(r, θ, ϕ)` and `Cylindrical(r, θ, z)`.
-
+We do provide a few specialist coordinate types. The `Polar(r, θ)` type is a 2D
+polar representation of a point, and similarly in 3D we have defined
+`Spherical(r, θ, ϕ)` and `Cylindrical(r, θ, z)`.
 
 #### Coordinate system transformations
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-FixedSizeArrays
+FixedSizeArrays 0.2.2
 Rotations

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -26,7 +26,7 @@ export RotMatrix, Quaternion, SpQuat, AngleAxis, EulerAngles, ProperEulerAngles
 
 # Core methods
 export transform, compose, ∘, transform_deriv, transform_deriv_params
-export AbstractTransformation, IdentityTransformation
+export Transformation, IdentityTransformation
 
 # 2D coordinate systems and their transformations
 export Polar

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -6,14 +6,14 @@ export Point # Use Point{N, T} from FixedSizedArrays for Cartesian frames
 # TODO: move these over to FixedSizeArrays at some point
 function Base.vcat(v1::Vec, v2::Vec)
     (v1p, v2p) = promote(v1, v2)
-    Vec(v1p._..., v2p._...)
+    Vec(Tuple(v1p)..., Tuple(v2p)...)
 end
 function Base.hcat{N,M,P}(m1::Mat{N,M}, m2::Mat{N,P})
     (m1p, m2p) = promote(m1, m2)
-    Mat(m1p._..., m2p._...)
+    Mat(Tuple(m1p)..., Tuple(m2p)...)
 end
 @generated function Base.vcat{N,M,P}(m1::Mat{M,N}, m2::Mat{P,N})
-    exprs = ntuple(i -> :( (m1p._[$i]..., m2p._[$i]...) ) , N)
+    exprs = ntuple(i -> :( (Tuple(m1p)[$i]..., Tuple(m2p)[$i]...) ) , N)
     expr = Expr(:tuple, exprs...)
     quote
         (m1p, m2p) = promote(m1, m2)

--- a/src/commontransformations.jl
+++ b/src/commontransformations.jl
@@ -11,6 +11,7 @@ Construct the `Translation` transformation for translating Cartesian points.
 immutable Translation{T} <: Transformation
     dx::T
 end
+Translation(x::Tuple) = Translation(Vec(x))
 Translation(x,y) = Translation(Vec(x,y))
 Translation(x,y,z) = Translation(Vec(x,y,z))
 Base.show(io::IO, trans::Translation) = print(io, "Translation$((trans.dx...))")
@@ -18,6 +19,8 @@ Base.show(io::IO, trans::Translation) = print(io, "Translation$((trans.dx...))")
 function transform(trans::Translation, x)
     x + trans.dx
 end
+
+transform(trans::Translation, x::Tuple) = Tuple(Vec(x) + trans.dx)
 
 Base.inv(trans::Translation) = Translation(-trans.dx)
 
@@ -168,6 +171,8 @@ function transform(trans::Rotation, x::FixedVector{3})
     (m, x2) = promote(trans.matrix, x)
     (typeof(x2))(m * Vec(x2))
 end
+
+transform(trans::Rotation, x::Tuple) = Tuple(transform(trans, Vec(x)))
 
 transform_deriv(trans::Rotation, x) = trans.matrix # It's a linear transformation, so this is easy!
 
@@ -339,7 +344,7 @@ function transform(trans::RotationYZ, x::FixedVector{3})
     (sincos, x2) = promote(Vec(trans.sin, trans.cos), x)
     (typeof(x2))(x2[1], x[2]*sincos[2] - x[3]*sincos[1], x[2]*sincos[1] + x[3]*sincos[2])
 end
-function transform{T}(trans::RotationXY{T}, x)
+function transform{T}(trans::RotationYZ{T}, x)
     Z = zero(T)
     I = one(T)
 
@@ -348,13 +353,13 @@ function transform{T}(trans::RotationXY{T}, x)
      Z trans.sin  trans.cos] * x
 end
 
-transform(trans::RotationZX, x::Vector) =    [x[3]*trans.cos - x[1]*trans.sin, x[2], x[3]*trans.sin + x[1]*trans.cos]
-transform(trans::RotationZX, x::NTuple{3}) = (x[3]*trans.cos - x[1]*trans.sin, x[2], x[3]*trans.sin + x[1]*trans.cos)
+transform(trans::RotationZX, x::Vector) =    [x[3]*trans.sin + x[1]*trans.cos, x[2], x[3]*trans.cos - x[1]*trans.sin]
+transform(trans::RotationZX, x::NTuple{3}) = (x[3]*trans.sin + x[1]*trans.cos, x[2], x[3]*trans.cos - x[1]*trans.sin)
 function transform(trans::RotationZX, x::FixedVector{3})
     (sincos, x2) = promote(Vec(trans.sin, trans.cos), x)
     (typeof(x2))(x[3]*sincos[1] + x[1]*sincos[2], x2[2], x[3]*sincos[2] - x[1]*sincos[1])
 end
-function transform{T}(trans::RotationXY{T}, x)
+function transform{T}(trans::RotationZX{T}, x)
     Z = zero(T)
     I = one(T)
 

--- a/src/commontransformations.jl
+++ b/src/commontransformations.jl
@@ -1,39 +1,35 @@
-# Some common transformations are defined here
-
 ###################
 ### Translation ###
 ###################
 """
-    Translation{N, T}(dx) <: AbstractTransformation{FixedVector{N}, FixedVector{N}}
-    Translation(x, y)        (2D)
-    Translation(x, y, z)     (3D)
+    Translation(dv) <: Transformation
+    Translation(dx, dy)       (2D)
+    Translation(dx, dy, dz)   (3D)
 
-Construct the `Translation` transformation for translating Cartesian points
-(`FixedVector`s).
+Construct the `Translation` transformation for translating Cartesian points.
 """
-immutable Translation{N, T} <: AbstractTransformation{FixedVector{N}, FixedVector{N}}
-    dx::Vec{N, T}
+immutable Translation{T} <: Transformation
+    dx::T
 end
 Translation(x,y) = Translation(Vec(x,y))
 Translation(x,y,z) = Translation(Vec(x,y,z))
-Base.show(io::IO, trans::Translation) = print(io, "Translation$(trans.dx._)")
+Base.show(io::IO, trans::Translation) = print(io, "Translation$((trans.dx...))")
 
-function transform{N}(trans::Translation{N}, x::FixedVector{N})
-    (x_promoted, dx_promoted) = promote(x, trans.dx) # Force same data type
-    x_promoted + (typeof(x_promoted))(dx_promoted) # Force same base type
+function transform(trans::Translation, x)
+    x + trans.dx
 end
 
 Base.inv(trans::Translation) = Translation(-trans.dx)
 
-function compose{N}(trans1::Translation{N}, trans2::Translation{N})
+function compose(trans1::Translation, trans2::Translation)
     Translation(trans1.dx + trans2.dx)
 end
 
-function transform_deriv{N}(trans::Translation{N}, x::Point{N})
+function transform_deriv(trans::Translation, x)
     I
 end
 
-function transform_deriv_params{N}(trans::Translation{N}, x::Point{N})
+function transform_deriv_params(trans::Translation, x)
     I
 end
 
@@ -42,47 +38,17 @@ end
 ####################
 
 """
-    RotationPolar(angle)
-
-Construct the `RotationPolar` transformation for rotating `Polar` points about
-the origin.
-"""
-immutable RotationPolar{T} <: AbstractTransformation{Polar, Polar}
-    angle::T
-end
-Base.show(io::IO, r::RotationPolar) = print(io, "RotationPolar($(r.angle))")
-
-
-function transform(trans::RotationPolar, x::Polar)
-    Polar(x.r, x.θ + trans.angle)
-end
-
-function transform_deriv{T}(trans::RotationPolar, x::Polar{T})
-    @fsa [ zero(T) zero(T);
-           zero(T) one(T)  ]
-end
-
-function transform_deriv_params{T}(trans::RotationPolar, x::Polar{T})
-    @fsa [ zero(T);
-           one(T)  ]
-end
-
-Base.inv(trans::RotationPolar) = RotationPolar(-trans.angle)
-
-compose(t1::RotationPolar, t2::RotationPolar) = RotationPolar(t1.angle + t2.angle)
-
-"""
     Rotation2D(angle)
 
 Construct the `Rotation2D` transformation for rotating 2D Cartesian points
 (i.e. `FixedVector{2}`s) about the origin.
 """
-immutable Rotation2D{T} <: AbstractTransformation{FixedVector, FixedVector{2}}
+immutable Rotation2D{T} <: Transformation
     angle::T
     sin::T
     cos::T
 end
-Base.show(io::IO, r::Rotation2D) = print(io, "Rotation2D($(r.angle))")
+Base.show(io::IO, r::Rotation2D) = print(io, "Rotation2D($(r.angle) rad)")
 
 function Rotation2D(a)
     s = sin(a)
@@ -90,25 +56,59 @@ function Rotation2D(a)
     return Rotation2D(a,s,c)
 end
 
+# A variety of specializations for all occassions!
 function transform(trans::Rotation2D, x::FixedVector{2})
     (sincos, x2) = promote(Vec(trans.sin, trans.cos), x)
     (typeof(x2))(x[1]*sincos[2] - x[2]*sincos[1], x[1]*sincos[1] + x[2]*sincos[2])
 end
 
-function transform_deriv(trans::Rotation2D, x::FixedVector{2})
+transform(trans::Rotation2D, x::NTuple{2})             = (x[1]*trans.cos - x[2]*trans.sin, x[1]*trans.sin + x[2]*trans.cos)
+transform{T1,T2}(trans::Rotation2D{T1}, x::Vector{T2}) = [x[1]*trans.cos - x[2]*trans.sin, x[1]*trans.sin + x[2]*trans.cos]
+
+# E.g. for ArrayFire, this might work better than the below?
+function transform{T1,T2}(trans::Rotation2D{T1}, x::AbstractVector{T2})
+    out = similar(x, promote_type(T1,T2))
+    out[1] = x[1]*trans.cos - x[2]*trans.sin
+    out[2] = x[1]*trans.sin + x[2]*trans.cos
+    return out
+end
+
+function transform(trans::Rotation2D, x)
+    [ trans.cos -trans.sin;
+      trans.sin  trans.cos ] * x
+end
+
+function transform(trans::Rotation2D, x::Polar)
+    Polar(x.r, x.θ + trans.angle)
+end
+
+function transform_deriv(trans::Rotation2D, x)
     @fsa [ trans.cos -trans.sin;
            trans.sin  trans.cos ]
 end
 
-function transform_deriv_params(trans::Rotation2D, x::FixedVector{2})
+function transform_deriv{T}(trans::Rotation2D, x::Polar{T})
+    @fsa [ zero(T) zero(T);
+           zero(T) one(T)  ]
+end
+
+function transform_deriv_params(trans::Rotation2D, x)
     # 2x1 transformation matrix
     Mat(-trans.sin*x[1] - trans.cos*x[2],
          trans.cos*x[1] - trans.sin*x[2] )
 end
 
+function transform_deriv_params{T}(trans::Rotation2D, x::Polar{T})
+    @fsa [ zero(T);
+           one(T)  ]
+end
+
 Base.inv(trans::Rotation2D) = Rotation2D(-trans.angle, -trans.sin, trans.cos)
 
 compose(t1::Rotation2D, t2::Rotation2D) = Rotation2D(t1.angle + t2.angle)
+
+
+
 
 #####################
 ### Rotation (3D) ###
@@ -119,9 +119,9 @@ compose(t1::Rotation2D, t2::Rotation2D) = Rotation2D(t1.angle + t2.angle)
 Construct the `Rotation` transformation for rotating 3D Cartesian points
 (i.e. `FixedVector{3}`s) about the origin. I
 """
-immutable Rotation{R, T} <: AbstractTransformation{FixedVector{3}, FixedVector{3}}
+immutable Rotation{R, T} <: Transformation
     rotation::R
-    matrix::Mat{3,3,T}
+    matrix::Mat{3,3,T} # Should we enforce this storage, or merely "suggest" it
 end
 Base.show(io::IO, r::Rotation) = print(io, "Rotation($(r.rotation))")
 Base.show(io::IO, r::Rotation{Void}) = print(io, "Rotation($(r.matrix))")
@@ -133,8 +133,8 @@ Construct the `Rotation` transformation for rotating 3D Cartesian points
 (i.e. `FixedVector{3}`s) about the origin. `matrix` is a 3×3 `Matrix` or `Mat`,
 and is assumed to be orthogonal.
 """
-Rotation{T}(r::RotMatrix{T}) = Rotation(nothing, r) # R=Void represents direct parameterization by the marix (assumed to be Hermitian)
-Rotation{T}(r::Matrix{T}) = Rotation(nothing, Mat{3,3,T}(r))
+Rotation{T}(r::RotMatrix{T}) = Rotation(nothing, r) # R=Void represents direct parameterization by the marix (assumed to be orthogonal/unitary)
+Rotation{T}(r::Matrix{T}) = Rotation(nothing, Mat{3,3,T}(r)) # Should we enforce this storage, or merely "suggest" it
 """
     Rotation(R)
 
@@ -160,27 +160,31 @@ Base.isapprox(a::Rotation, b::Rotation; kwargs...) = isapprox(a.matrix, b.matrix
 Base.isapprox{T}(a::Rotation{T}, b::Rotation{T}; kwargs...) = isapprox(a.matrix, b.matrix; kwargs...) && isapprox(a.rotation, b.rotation; kwargs...)
 Base.isapprox(a::Rotation{Void}, b::Rotation{Void}; kwargs...) = isapprox(a.matrix, b.matrix; kwargs...)
 
+function transform(trans::Rotation, x)
+    trans.matrix * x
+end
+
 function transform(trans::Rotation, x::FixedVector{3})
     (m, x2) = promote(trans.matrix, x)
     (typeof(x2))(m * Vec(x2))
 end
 
-transform_deriv(trans::Rotation, x::FixedVector{3}) = trans.matrix # It's a linear transformation, so this is easy!
+transform_deriv(trans::Rotation, x) = trans.matrix # It's a linear transformation, so this is easy!
 
-function transform_deriv_params{T1,T2}(trans::Rotation{Void,T1}, x::FixedVector{3,T2})
+function transform_deriv_params{T}(trans::Rotation{Void,T}, x)
     # This derivative isn't projected into the orthogonal/Hermition tangent
     # plane. It would be acheived by:
     # Δ -> (Δ - R Δ' R) / 2
 
     # The matrix gives 9 parameters...
-    Z = zero(promote_type(T1,T2))
+    Z = zero(promote_type(T, eltype(x)))
     @fsa [ x[1] x[2] x[3] Z Z Z Z Z Z;
            Z Z Z x[1] x[2] x[3] Z Z Z;
            Z Z Z Z Z Z x[1] x[2] x[3] ]
 end
 
 
-function transform_deriv_params{T1,T2}(trans::Rotation{Quaternion{T1},T1}, x::FixedVector{3,T2})
+function transform_deriv_params{T1,T2}(trans::Rotation{Quaternion{T1},T2}, x)
     #=
     # From Rotations.jl package
     # get rotation matrix from quaternion
@@ -248,11 +252,12 @@ compose(t1::Rotation, t2::Rotation) = Rotation(nothing, t1.matrix*t2.matrix) # A
     RotationXY(angle)
 
 Construct the `RotationXY` transformation for rotating 3D Cartesian points
-(i.e. `FixedVector{3}`s) through the X-Y plane (around the Z axis).
+(e.g. `Vector`, `NTuple{3}`, or `FixedVector{3}`) through the X-Y plane (around
+the Z axis).
 
 (see also `Rotation`, `RotationYZ`, `RotationZX` and `euler_rotation`)
 """
-immutable RotationXY{T} <: AbstractTransformation{FixedVector{3}, FixedVector{3}}
+immutable RotationXY{T} <: Transformation
     angle::T
     sin::T
     cos::T
@@ -261,11 +266,12 @@ end
     RotationYZ(angle)
 
 Construct the `RotationYZ` transformation for rotating 3D Cartesian points
-(i.e. `FixedVector{3}`s) through the Y-Z plane (around the X axis).
+(e.g. `Vector`, `NTuple{3}`, or `FixedVector{3}`) through the Y-Z plane (around
+the X axis).
 
 (see also `Rotation`, `RotationXY`, `RotationZX` and `euler_rotation`)
 """
-immutable RotationYZ{T} <: AbstractTransformation{FixedVector{3}, FixedVector{3}}
+immutable RotationYZ{T} <: Transformation
     angle::T
     sin::T
     cos::T
@@ -274,11 +280,12 @@ end
     RotationZX(angle)
 
 Construct the `RotationZX` transformation for rotating 3D Cartesian points
-(i.e. `FixedVector{3}`s) through the Z-X plane (around the Y axis).
+(e.g. `Vector`, `NTuple{3}`, or `FixedVector{3}`) through the Z-X plane (around
+the Y axis).
 
 (see also `Rotation`, `RotationXY`, `RotationYZ` and `euler_rotation`)
 """
-immutable RotationZX{T} <: AbstractTransformation{FixedVector{3}, FixedVector{3}}
+immutable RotationZX{T} <: Transformation
     angle::T
     sin::T
     cos::T
@@ -310,34 +317,67 @@ Base.show(io::IO, r::RotationXY) = print(io, "RotationXY($(r.angle))")
 Base.show(io::IO, r::RotationYZ) = print(io, "RotationYZ($(r.angle))")
 Base.show(io::IO, r::RotationZX) = print(io, "RotationZX($(r.angle))")
 
+# It's a little fiddly to support all possible point container types, but this should do a good majority of them!
+transform(trans::RotationXY, x::Vector) =    [x[1]*trans.cos - x[2]*trans.sin, x[1]*trans.sin + x[2]*trans.cos, x[3]]
+transform(trans::RotationXY, x::NTuple{3}) = (x[1]*trans.cos - x[2]*trans.sin, x[1]*trans.sin + x[2]*trans.cos, x[3])
 function transform(trans::RotationXY, x::FixedVector{3})
     (sincos, x2) = promote(Vec(trans.sin, trans.cos), x)
     (typeof(x2))(x[1]*sincos[2] - x[2]*sincos[1], x[1]*sincos[1] + x[2]*sincos[2], x2[3])
 end
+function transform{T}(trans::RotationXY{T}, x)
+    Z = zero(T)
+    I = one(T)
+
+    [trans.cos -trans.sin Z;
+    trans.sin  trans.cos Z;
+    Z          Z         I ] * x
+end
+
+transform(trans::RotationYZ, x::Vector) =    [x[1], x[2]*trans.cos - x[3]*trans.sin, x[2]*trans.sin + x[3]*trans.cos]
+transform(trans::RotationYZ, x::NTuple{3}) = (x[1], x[2]*trans.cos - x[3]*trans.sin, x[2]*trans.sin + x[3]*trans.cos)
 function transform(trans::RotationYZ, x::FixedVector{3})
     (sincos, x2) = promote(Vec(trans.sin, trans.cos), x)
     (typeof(x2))(x2[1], x[2]*sincos[2] - x[3]*sincos[1], x[2]*sincos[1] + x[3]*sincos[2])
 end
+function transform{T}(trans::RotationXY{T}, x)
+    Z = zero(T)
+    I = one(T)
+
+    [I Z          Z        ;
+     Z trans.cos -trans.sin;
+     Z trans.sin  trans.cos] * x
+end
+
+transform(trans::RotationZX, x::Vector) =    [x[3]*trans.cos - x[1]*trans.sin, x[2], x[3]*trans.sin + x[1]*trans.cos]
+transform(trans::RotationZX, x::NTuple{3}) = (x[3]*trans.cos - x[1]*trans.sin, x[2], x[3]*trans.sin + x[1]*trans.cos)
 function transform(trans::RotationZX, x::FixedVector{3})
     (sincos, x2) = promote(Vec(trans.sin, trans.cos), x)
     (typeof(x2))(x[3]*sincos[1] + x[1]*sincos[2], x2[2], x[3]*sincos[2] - x[1]*sincos[1])
 end
+function transform{T}(trans::RotationXY{T}, x)
+    Z = zero(T)
+    I = one(T)
 
-function transform_deriv(trans::RotationXY, x::FixedVector{3})
+    [ trans.cos Z trans.sin;
+      Z         I Z        ;
+     -trans.sin Z trans.cos] * x
+end
+
+function transform_deriv(trans::RotationXY, x)
     Z = zero(trans.cos)
     I = one(trans.cos)
     @fsa [ trans.cos -trans.sin Z;
            trans.sin  trans.cos Z;
            Z          Z         I]
 end
-function transform_deriv(trans::RotationYZ, x::FixedVector{3})
+function transform_deriv(trans::RotationYZ, x)
     Z = zero(trans.cos)
     I = one(trans.cos)
     @fsa [ I  Z         Z;
            Z  trans.cos -trans.sin;
            Z  trans.sin  trans.cos ]
 end
-function transform_deriv(trans::RotationZX, x::FixedVector{3})
+function transform_deriv(trans::RotationZX, x)
     Z = zero(trans.cos)
     I = one(trans.cos)
     @fsa [ trans.cos Z trans.sin;
@@ -345,21 +385,21 @@ function transform_deriv(trans::RotationZX, x::FixedVector{3})
           -trans.sin Z trans.cos ]
 end
 
-function transform_deriv_params(trans::RotationXY, x::FixedVector{3})
+function transform_deriv_params(trans::RotationXY, x)
     # 3x1 transformation matrix
     Z = zero(promote_type(typeof(trans.cos), eltype(x)))
     Mat(-trans.sin*x[1] - trans.cos*x[2],
          trans.cos*x[1] - trans.sin*x[2],
          Z)
 end
-function transform_deriv_params(trans::RotationYZ, x::FixedVector{3})
+function transform_deriv_params(trans::RotationYZ, x)
     # 3x1 transformation matrix
     Z = zero(promote_type(typeof(trans.cos), eltype(x)))
     Mat( Z,
         -trans.sin*x[2] - trans.cos*x[3],
          trans.cos*x[2] - trans.sin*x[3])
 end
-function transform_deriv_params(trans::RotationZX, x::FixedVector{3})
+function transform_deriv_params(trans::RotationZX, x)
     # 3x1 transformation matrix
     Z = zero(promote_type(typeof(trans.cos), eltype(x)))
     Mat( trans.cos*x[3] - trans.sin*x[1],

--- a/src/core.jl
+++ b/src/core.jl
@@ -6,115 +6,45 @@
 # transform_deriv() and transform_deriv_params()
 
 """
-`AbstractTransformation{OutType, InType}` defines a simple interface for
-performing transformations. Subtypes should be able to apply a coordinate system
+The `Transformation` supertype defines a simple interface for performing
+transformations. Subtypes should be able to apply a coordinate system
 transformation on the correct data types by overloading `transform()`, and
 usually would have the corresponding inverse transformation defined by `Base.inv()`.
 Efficient compositions can optionally be defined by `compose()` (equivalently `∘`).
-
-Furthermore, transformations can be combined in a tuple to be applied in parallel
-to a tuple of inputs (for example, performing a rotation on a spatial variable
-while leaving the time variable constant). This becomes particularly powerful
-when
 """
-abstract AbstractTransformation{OutType, InType}
-
-# Some basic introspection
-@inline intype{OutType, InType}(::AbstractTransformation{OutType, InType}) = InType
-@inline outtype{OutType, InType}(::AbstractTransformation{OutType, InType}) = OutType
-
-# Unfortunately some operations on abstract types are difficult
-@generated function intype{T <: AbstractTransformation}(::Type{T})
-    S = T
-    while S.name != AbstractTransformation.name
-        S = super(S)
-        if S == Any
-            str = "Error determining intype of $T"
-            return :(error(str))
-        end
-    end
-
-    return :($(S.parameters[2]))
-end
-
-@generated function outtype{T <: AbstractTransformation}(::Type{T})
-    S = T
-    while S.name != AbstractTransformation.name
-        S = super(S)
-        if S == Any
-            str = "Error determining outtype of $T"
-            return :(error(str))
-        end
-    end
-
-    return :($(S.parameters[1]))
-end
-
-# TODO generated functions for intype and outtype of tuples of AbstractTransformations
-
-
-# Built-in identity transform
-immutable IdentityTransformation{T} <: AbstractTransformation{T,T}; end
+abstract Transformation
 
 """
-    transform(trans::AbstractTransformation, x)
+The `IdentityTransformation` is a singleton `Transformation` that returns the
+input unchanged, similar to `identity`.
+"""
+immutable IdentityTransformation <: Transformation; end
+
+"""
+    transform(trans::Transformation, x)
 
 A transformation `trans` is explicitly applied to data x, returning the
 coordinates in the new coordinate system.
 """
-function transform{OutType, InType}(trans::AbstractTransformation{OutType, InType}, x)
-    if isa(x, Vector) && eltype(x) <: InType # TODO remove this function for julia-0.5 where vectorized functions are falling out of favour
-        [transform(trans, point) for point in x]
-    else
-        error("The transform of datatype $(typeof(x)) is not defined for transformation $trans.")
-    end
+function transform(trans::Transformation, x)
+    error("The transform of datatype $(typeof(x)) is not defined for transformation $trans.")
 end
 
-"""
-transform((trans1, trans2, ...), (x1, x2, ...))
-
-A set of transformations `trans1`, etc, are applied in parallel to data `x1`, etc,
-returning a tuple of the transformed coordinates.
-"""
-function transform{N}(trans::NTuple{N,AbstractTransformation}, x::NTuple{N})
-    # TODO generated function for type stability in Julia 0.4
-    return ntuple(i->transform(trans[i], x[i]), Val{N})
-end
-
-transform{T}(::IdentityTransformation{T}, x::T) = x
+@inline transform(::IdentityTransformation, x) = x
 
 
 """
 A `ComposedTransformation` simply executes two transformations successively, and
 is the fallback output type of `compose()`.
 """
-immutable ComposedTransformation{OutType, InType, T1 <: Union{AbstractTransformation, Tuple{Vararg{AbstractTransformation}}}, T2 <: Union{AbstractTransformation, Tuple{Vararg{AbstractTransformation}}}} <: AbstractTransformation{OutType, InType}
+immutable ComposedTransformation{T1 <: Transformation, T2 <: Transformation} <: Transformation
     t1::T1
     t2::T2
-
-    function ComposedTransformation(trans1::T1, trans2::T2)
-        check_composable(OutType, InType, trans1, trans2)
-        new(trans1,trans2)
-    end
 end
-@generated function check_composable{OutType, InType}(out_type::Type{OutType},in_type::Type{InType},trans1::Union{AbstractTransformation, Tuple{Vararg{AbstractTransformation}}}, trans2::Union{AbstractTransformation, Tuple{Vararg{AbstractTransformation}}})
-    if InType != intype(trans2)
-        str = "Can't compose transformations: input coordinates types $InType and $(intype(trans2)) do not match."
-        error(str)
-    elseif OutType != outtype(trans1)
-        str = "Can't compose transformations: output coordinates types $OutType and $(outtype(trans1)) do not match."
-        error(str)
-    elseif typeintersect(intype(trans1), outtype(trans2)) == Union{}
-        error("Can't compose transformations: intermediate coordinates types $(intype(trans1)) and $(outtype(trans2)) do not intersect.")
-    else
-        return nothing
-    end
-end
-check_composable{OutType, InType, T}(::Type{OutType}, ::Type{InType}, ::AbstractTransformation{OutType,T}, ::AbstractTransformation{T,InType}) = nothing # Generates no code if they match... empty function
 
 Base.show(io::IO, trans::ComposedTransformation) = print(io, "($(trans.t1) ∘ $(trans.t2))")
 
-@inline function transform{OutType, InType}(trans::ComposedTransformation{OutType, InType}, x::InType)
+@inline function transform(trans::ComposedTransformation, x)
     transform(trans.t1, transform(trans.t2, x))
 end
 
@@ -128,50 +58,47 @@ will create a `ComposedTransformation`, however this method can be overloaded
 for efficiency (e.g. two affine transformations naturally compose to a single
 affine transformation).
 """
-function compose(trans1::AbstractTransformation, trans2::AbstractTransformation)
-    ComposedTransformation{outtype(trans1), intype(trans2), typeof(trans1), typeof(trans2)}(trans1, trans2)
+function compose(trans1::Transformation, trans2::Transformation)
+    ComposedTransformation(trans1, trans2)
 end
 
-compose{InOutType}(trans::IdentityTransformation{InOutType}, ::IdentityTransformation{InOutType}) = trans
-compose{OutType, InType}(::IdentityTransformation{OutType}, trans::AbstractTransformation{OutType, InType}) = trans
-compose{OutType, InType}(trans::AbstractTransformation{OutType, InType}, ::IdentityTransformation{InType}) = trans
-
-# TODO compose for tuples of AbstractTransformations (generated function)
+compose(trans::IdentityTransformation, ::IdentityTransformation) = trans
+compose(::IdentityTransformation, trans::Transformation) = trans
+compose(trans::Transformation, ::IdentityTransformation) = trans
 
 const ∘ = compose
 
+
 """
-    inv(trans::AbstractTransformation)
+    inv(trans::Transformation)
 
 Returns the inverse (or reverse) of the transformation `trans`
 """
-function Base.inv(trans::AbstractTransformation)
+function Base.inv(trans::Transformation)
     error("Inverse transformation for $(typeof(trans)) has not been defined.")
 end
 
 Base.inv(trans::ComposedTransformation) = inv(trans.t2) ∘ inv(trans.t1)
 Base.inv(trans::IdentityTransformation) = trans
 
-# TODO compose for inverse of AbstractTransformations (generated function)
 
 """
-    transform_deriv(trans::AbstractTransformation, x)
+    transform_deriv(trans::Transformation, x)
 
 A matrix describing how differentials on the parameters of `x` flow through to
 the output of transformation `trans`.
 """
-transform_deriv(::AbstractTransformation, x) = error("Differential matrix of transform $trans with input $x not defined")
+transform_deriv(::Transformation, x) = error("Differential matrix of transform $trans with input $x not defined")
 
-transform_deriv{T}(::IdentityTransformation{T}, x::T) = I
+transform_deriv(::IdentityTransformation, x) = I
 
-function transform_deriv{OutType, InType}(trans::ComposedTransformation{OutType, InType}, x::InType)
+function transform_deriv(trans::ComposedTransformation, x)
     x2 = transform(trans.t2, x)
     m1 = transform_deriv(trans.t1, x2)
     m2 = transform_deriv(trans.t2, x)
     return m1 * m2
 end
 
-# TODO compose for derivatives of AbstractTransformations (generated function)
 
 """
     transform_deriv_params(trans::AbstractTransformation, x)
@@ -179,16 +106,14 @@ end
 A matrix describing how differentials on the parameters of `trans` flow through
 to the output of transformation `trans` given input `x`.
 """
-transform_deriv(::AbstractTransformation, x) = error("Differential matrix of parameters of transform $trans with input $x not defined")
+transform_deriv(::Transformation, x) = error("Differential matrix of parameters of transform $trans with input $x not defined")
 
-transform_deriv_params{T}(::IdentityTransformation{T}, x::T) = error("IdentityTransformation has no parameters")
+transform_deriv_params(::IdentityTransformation, x) = error("IdentityTransformation has no parameters")
 
-function transform_deriv_params{OutType, InType}(trans::ComposedTransformation{OutType, InType}, x::InType)
+function transform_deriv_params(trans::ComposedTransformation, x)
     x2 = transform(trans.t2, x)
     m1 = transform_deriv(trans.t1, x2)
     p2 = transform_deriv_params(trans.t2, x)
     p1 = transform_deriv_params(trans.t1, x2)
     return hcat(p1, m1*p2)
 end
-
-# TODO compose for parameter derivatives of AbstractTransformations (generated function)

--- a/test/commontransformations.jl
+++ b/test/commontransformations.jl
@@ -11,6 +11,8 @@
 
         # Transform
         @test transform(trans, x) === Point(3.0, 1.0)
+        @test transform(trans, Tuple(x)) === (3.0, 1.0)
+        @test transform(trans, collect(x)) === Vec(3.0, 1.0)
 
         # Transform derivative
         m1 = transform_deriv(trans, x)
@@ -61,6 +63,8 @@
 
         # Transform
         @test transform(trans, x) ≈ x2
+        @test Vec(transform(trans, Tuple(x))) ≈ x2
+        @test transform(trans, collect(x)) ≈ collect(x2)
 
         # Transform derivative
         x = Point(2.0,1.0)
@@ -116,6 +120,9 @@
 
             y = transform(trans, x)
             @test y == R * Vec(1.0, 2.0, 3.0)
+            @test transform(trans, Tuple(x)) == Tuple(R * Vec(1.0, 2.0, 3.0))
+            @test transform(trans, collect(x)) == R * Vec(1.0, 2.0, 3.0)
+
 
             x_gn = Point(Dual(1.0,(1.,0.,0.)), Dual(2.0,(0.,1.,0.)), Dual(3.0,(0.,0.,1.)))
             y_gn = transform(trans, x_gn)
@@ -219,6 +226,8 @@
 
             # Transform
             @test transform(trans, x) ≈ x2
+            @test Vec(transform(trans, Tuple(x))) ≈ x2
+            @test Vec(transform(trans, collect(x))) ≈ x2
 
             # Transform derivative
             x = Point(2.0,1.0,3.0)
@@ -257,6 +266,8 @@
 
             # Transform
             @test transform(trans, x) ≈ x2
+            @test Vec(transform(trans, Tuple(x))) ≈ x2
+            @test Vec(transform(trans, collect(x))) ≈ x2
 
             # Transform derivative
             x = Point(2.0,1.0,3.0)
@@ -295,6 +306,8 @@
 
             # Transform
             @test transform(trans, x) ≈ x2
+            @test Vec(transform(trans, Tuple(x))) ≈ x2
+            @test Vec(transform(trans, collect(x))) ≈ x2
 
             # Transform derivative
             x = Point(2.0,1.0,3.0)

--- a/test/commontransformations.jl
+++ b/test/commontransformations.jl
@@ -23,15 +23,15 @@
         @test m2 == eye(2)
     end
 
-    @testset "RotationPolar" begin
+    @testset "Rotation2D on Polar" begin
         p = Polar(2.0, 1.0)
-        trans = RotationPolar(1.0)
+        trans = Rotation2D(1.0)
 
         # Inverse
-        @test inv(trans) == RotationPolar(-1.0)
+        @test inv(trans) == Rotation2D(-1.0)
 
         # Composition
-        @test trans ∘ trans == RotationPolar(2.0)
+        @test trans ∘ trans == Rotation2D(2.0)
 
         # Transform
         @test transform(trans, p) == Polar(2.0, 2.0)

--- a/test/coordinatesystems.jl
+++ b/test/coordinatesystems.jl
@@ -2,8 +2,8 @@
     @testset "2D" begin
         c_from_p = CartesianFromPolar()
         p_from_c = PolarFromCartesian()
-        identity_c = IdentityTransformation{Point{2}}()
-        identity_p = IdentityTransformation{Polar}()
+        identity_c = IdentityTransformation()
+        identity_p = IdentityTransformation()
 
         @test inv(c_from_p) == p_from_c
         @test inv(p_from_c) == c_from_p
@@ -107,9 +107,9 @@
         cart_from_cyl = CartesianFromCylindrical()
         cyl_from_s = CylindricalFromSpherical()
         s_from_cyl = SphericalFromCylindrical()
-        identity_cart = IdentityTransformation{Point{3}}()
-        identity_s = IdentityTransformation{Spherical}()
-        identity_cyl = IdentityTransformation{Cylindrical}()
+        identity_cart = IdentityTransformation()
+        identity_s = IdentityTransformation()
+        identity_cyl = IdentityTransformation()
 
         # inverses
         @test inv(s_from_cart) == cart_from_s

--- a/test/coordinatesystems.jl
+++ b/test/coordinatesystems.jl
@@ -22,6 +22,8 @@
         xy = Point(1.0, 2.0)
         rθ = Polar(2.23606797749979, 1.1071487177940904)
         @test transform(p_from_c, xy) ≈ rθ
+        @test transform(p_from_c, Tuple(xy)) ≈ rθ
+        @test transform(p_from_c, collect(xy)) ≈ rθ
         @test transform(c_from_p, rθ) ≈ xy
 
         # TODO - define some convenience functions to create the gradient numbers and unpack the arrays.
@@ -142,6 +144,8 @@
         xyz = Point(1.0, 2.0, 3.0)
         rθϕ = Spherical(3.7416573867739413, 1.1071487177940904, 0.9302740141154721)
         @test transform(s_from_cart, xyz) ≈ rθϕ
+        @test transform(s_from_cart, Tuple(xyz)) ≈ rθϕ
+        @test transform(s_from_cart, collect(xyz)) ≈ rθϕ
         @test transform(cart_from_s, rθϕ) ≈ xyz
 
         xyz_gn = Point(Dual(1.0, (1.0, 0.0, 0.0)), Dual(2.0, (0.0, 1.0, 0.0)), Dual(3.0, (0.0, 0.0, 1.0)))
@@ -321,6 +325,8 @@
         xyz = Point(1.0, 2.0, 3.0)
         rθz = Cylindrical(2.23606797749979, 1.1071487177940904, 3.0)
         @test transform(cyl_from_cart, xyz) ≈ rθz
+        @test transform(cyl_from_cart, Tuple(xyz)) ≈ rθz
+        @test transform(cyl_from_cart, collect(xyz)) ≈ rθz
         @test transform(cart_from_cyl, rθz) ≈ xyz
 
         xyz_gn = Point(Dual(1.0, (1.0, 0.0, 0.0)), Dual(2.0, (0.0, 1.0, 0.0)), Dual(3.0, (0.0, 0.0, 1.0)))

--- a/test/core.jl
+++ b/test/core.jl
@@ -2,13 +2,7 @@
     # Can't do much without a transformation, and the only one defined in
     # core.jl is IdentityTransformation... will have to test
     # ComposeTransformation in test/commontransformations.jl
-    T = Point{3}
-    identity_trans = IdentityTransformation{T}()
-
-    @test CoordinateTransformations.outtype(identity_trans) == T
-    @test CoordinateTransformations.intype(identity_trans) == T
-    @test CoordinateTransformations.outtype(IdentityTransformation{T}) == T
-    @test CoordinateTransformations.intype(IdentityTransformation{T}) == T
+    identity_trans = IdentityTransformation()
 
     @test inv(identity_trans) == identity_trans
 
@@ -16,7 +10,4 @@
 
     x = Point(1.0, 2.0, 3.0)
     @test transform(identity_trans, x) == x
-
-    v = [Point(1.0, 2.0, 3.0), Point(1.0, 2.0, 3.0)]
-    @test transform(identity_trans, v) == v
 end


### PR DESCRIPTION
`AbstractTransformation{InType,OutType}` has been simplified to
`Transformation`. Input and output types are no-longer constrained.

Closes #1.