### PR TITLE
Julia 0.6 fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
+Compat 0.11.0
 StaticArrays
 Rotations 0.3.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
-Compat 0.11.0
+Compat 0.17.0
 StaticArrays
 Rotations 0.3.0

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -2,7 +2,10 @@ __precompile__()
 
 module CoordinateTransformations
 
+using Compat
 using StaticArrays
+
+import Compat.∘
 
 using Rotations
 export RotMatrix, Quat, SpQuat, AngleAxis, RodriguesVec,

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -1,4 +1,4 @@
-abstract AbstractAffineMap <: Transformation
+@compat abstract type AbstractAffineMap <: Transformation end
 
 """
     Translation(v) <: AbstractAffineMap

--- a/src/core.jl
+++ b/src/core.jl
@@ -12,7 +12,7 @@ transformation on the correct data types by overloading the call method, and
 usually would have the corresponding inverse transformation defined by `Base.inv()`.
 Efficient compositions can optionally be defined by `compose()` (equivalently `∘`).
 """
-abstract Transformation
+@compat abstract type Transformation end
 
 """
 The `IdentityTransformation` is a singleton `Transformation` that returns the

--- a/src/core.jl
+++ b/src/core.jl
@@ -45,6 +45,7 @@ function Base.isapprox(trans1::ComposedTransformation, trans2::ComposedTransform
     isapprox(trans1.t1, trans2.t1; kwargs...) && isapprox(trans1.t2, trans2.t2; kwargs...)
 end
 
+const compose = ∘
 
 """
     compose(trans1, trans2)
@@ -63,8 +64,6 @@ end
 compose(trans::IdentityTransformation, ::IdentityTransformation) = trans
 compose(::IdentityTransformation, trans::Transformation) = trans
 compose(trans::Transformation, ::IdentityTransformation) = trans
-
-const ∘ = compose # TODO watch JuliaLang/julia#17184 and #17155 for v0.5 compatibility
 
 
 """

--- a/test/affine.jl
+++ b/test/affine.jl
@@ -75,7 +75,7 @@ CoordinateTransformations.transform_deriv(::SquareMe, x0) = diagm(2*x0)
 
         # Transform
         @test trans(x) === SVector(3.0, 1.0)
-        @test trans(collect(x)) === SVector(3.0, 1.0)
+        @test trans(collect(x)) == [3.0, 1.0]
 
         # Transform derivative
         m1 = transform_deriv(trans, x)


### PR DESCRIPTION
Some minor fixes for julia-0.6 deprecations and addition of \circ to Base.

Fixes #26 