### PR TITLE
Update syntax to v0.6+, drop v0.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ branches:
   only:
     - master
 julia:
-  - 0.5
+  - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.5
-Compat 0.17.0
+julia 0.6
 StaticArrays
 Rotations 0.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,14 @@
 environment:
   matrix:
-#  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-#  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+matrix:
+  allow_failures:
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/CoordinateTransformations.jl
+++ b/src/CoordinateTransformations.jl
@@ -2,10 +2,7 @@ __precompile__()
 
 module CoordinateTransformations
 
-using Compat
 using StaticArrays
-
-import Compat.∘
 
 using Rotations
 export RotMatrix, Quat, SpQuat, AngleAxis, RodriguesVec,

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -1,4 +1,4 @@
-@compat abstract type AbstractAffineMap <: Transformation end
+abstract type AbstractAffineMap <: Transformation end
 
 """
     Translation(v) <: AbstractAffineMap
@@ -8,7 +8,7 @@
 Construct the `Translation` transformation for translating Cartesian points by
 an offset `v = (dx, dy, ...)`
 """
-immutable Translation{V} <: AbstractAffineMap
+struct Translation{V} <: AbstractAffineMap
     v::V
 end
 Translation(x::Tuple) = Translation(SVector(x))
@@ -16,7 +16,7 @@ Translation(x,y) = Translation(SVector(x,y))
 Translation(x,y,z) = Translation(SVector(x,y,z))
 Base.show(io::IO, trans::Translation) = print(io, "Translation$((trans.v...))")
 
-function (trans::Translation{V}){V}(x)
+function (trans::Translation{V})(x) where {V}
     x + trans.v
 end
 
@@ -41,12 +41,12 @@ end
 A general linear transformation, constructed using `LinearMap(M)`
 for any matrix-like object `M`.
 """
-immutable LinearMap{M} <: AbstractAffineMap
+struct LinearMap{M} <: AbstractAffineMap
     m::M
 end
-Base.show(io::IO, trans::LinearMap)   = print(io, "LinearMap($(trans.m))") # TODO make this output more petite
+Base.show(io::IO, trans::LinearMap) = print(io, "LinearMap($(trans.m))") # TODO make this output more petite
 
-function (trans::LinearMap{M}){M}(x)
+function (trans::LinearMap{M})(x) where {M}
     trans.m * x
 end
 
@@ -95,12 +95,12 @@ converted into an affine approximation by linearizing about a point `x` using
 
 For transformations which are already affine, `x` may be omitted.
 """
-immutable AffineMap{M, V} <: AbstractAffineMap
+struct AffineMap{M, V} <: AbstractAffineMap
     m::M
     v::V
 end
 
-function (trans::AffineMap{M,V}){M,V}(x)
+function (trans::AffineMap{M, V})(x) where {M, V}
     trans.m * x + trans.v
 end
 

--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -4,7 +4,7 @@
 """
 `Polar{T}(r::T, θ::T)` - 2D polar coordinates
 """
-immutable Polar{T}
+struct Polar{T}
     r::T
     θ::T
 end
@@ -14,9 +14,9 @@ Base.eltype{T}(::Polar{T}) = T
 Base.eltype{T}(::Type{Polar{T}}) = T
 
 "`PolarFromCartesian()` - transformation from `AbstractVector` of length 2 to `Polar` type"
-immutable PolarFromCartesian <: Transformation; end
+struct PolarFromCartesian <: Transformation; end
 "`CartesianFromPolar()` - transformation from `Polar` type to `SVector{2}` type"
-immutable CartesianFromPolar <: Transformation; end
+struct CartesianFromPolar <: Transformation; end
 
 Base.show(io::IO, trans::PolarFromCartesian) = print(io, "PolarFromCartesian()")
 Base.show(io::IO, trans::CartesianFromPolar) = print(io, "CartesianFromPolar()")
@@ -57,8 +57,8 @@ compose(::CartesianFromPolar, ::PolarFromCartesian) = IdentityTransformation()
 
 # For convenience
 Base.convert(::Type{Polar}, v::AbstractVector) = PolarFromCartesian()(v)
-@inline Base.convert{V <: AbstractVector}(::Type{V}, p::Polar) = convert(V, CartesianFromPolar()(p))
-@inline Base.convert{V <: StaticVector}(::Type{V}, p::Polar) = convert(V, CartesianFromPolar()(p))
+@inline Base.convert(::Type{V}, p::Polar) where {V <: AbstractVector} = convert(V, CartesianFromPolar()(p))
+@inline Base.convert(::Type{V}, p::Polar) where {V <: StaticVector} = convert(V, CartesianFromPolar()(p))
 
 
 #############################
@@ -67,7 +67,7 @@ Base.convert(::Type{Polar}, v::AbstractVector) = PolarFromCartesian()(v)
 """
 Spherical(r, θ, ϕ) - 3D spherical coordinates
 """
-immutable Spherical{T}
+struct Spherical{T}
     r::T
     θ::T
     ϕ::T
@@ -80,7 +80,7 @@ Base.eltype{T}(::Type{Spherical{T}}) = T
 """
 Cylindrical(r, θ, z) - 3D cylindrical coordinates
 """
-immutable Cylindrical{T}
+struct Cylindrical{T}
     r::T
     θ::T
     z::T
@@ -91,17 +91,17 @@ Base.eltype{T}(::Cylindrical{T}) = T
 Base.eltype{T}(::Type{Cylindrical{T}}) = T
 
 "`SphericalFromCartesian()` - transformation from 3D point to `Spherical` type"
-immutable SphericalFromCartesian <: Transformation; end
+struct SphericalFromCartesian <: Transformation; end
 "`CartesianFromSpherical()` - transformation from `Spherical` type to `SVector{3}` type"
-immutable CartesianFromSpherical <: Transformation; end
+struct CartesianFromSpherical <: Transformation; end
 "`CylindricalFromCartesian()` - transformation from 3D point to `Cylindrical` type"
-immutable CylindricalFromCartesian <: Transformation; end
+struct CylindricalFromCartesian <: Transformation; end
 "`CartesianFromCylindrical()` - transformation from `Cylindrical` type to `SVector{3}` type"
-immutable CartesianFromCylindrical <: Transformation; end
+struct CartesianFromCylindrical <: Transformation; end
 "`CylindricalFromSpherical()` - transformation from `Spherical` type to `Cylindrical` type"
-immutable CylindricalFromSpherical <: Transformation; end
+struct CylindricalFromSpherical <: Transformation; end
 "`SphericalFromCylindrical()` - transformation from `Cylindrical` type to `Spherical` type"
-immutable SphericalFromCylindrical <: Transformation; end
+struct SphericalFromCylindrical <: Transformation; end
 
 Base.show(io::IO, trans::SphericalFromCartesian) = print(io, "SphericalFromCartesian()")
 Base.show(io::IO, trans::CartesianFromSpherical) = print(io, "CartesianFromSpherical()")
@@ -170,7 +170,7 @@ transform_deriv_params(::CylindricalFromCartesian, x::AbstractVector) = error("C
 function (::CartesianFromCylindrical)(x::Cylindrical)
     SVector(x.r * cos(x.θ), x.r * sin(x.θ), x.z)
 end
-function transform_deriv{T}(::CartesianFromCylindrical, x::Cylindrical{T})
+function transform_deriv(::CartesianFromCylindrical, x::Cylindrical{T}) where {T}
     sθ = sin(x.θ)
     cθ = cos(x.θ)
     @SMatrix [cθ      -x.r*sθ  zero(T) ;
@@ -227,10 +227,10 @@ compose(::SphericalFromCylindrical, ::CylindricalFromCartesian) = SphericalFromC
 Base.convert(::Type{Spherical}, v::AbstractVector) = SphericalFromCartesian()(v)
 Base.convert(::Type{Cylindrical}, v::AbstractVector) = CylindricalFromCartesian()(v)
 
-Base.convert{V <: AbstractVector}(::Type{V}, s::Spherical) = convert(V, CartesianFromSpherical()(s))
-Base.convert{V <: AbstractVector}(::Type{V}, c::Cylindrical) = convert(V, CartesianFromCylindrical()(c))
-Base.convert{V <: StaticVector}(::Type{V}, s::Spherical) = convert(V, CartesianFromSpherical()(s))
-Base.convert{V <: StaticVector}(::Type{V}, c::Cylindrical) = convert(V, CartesianFromCylindrical()(c))
+Base.convert(::Type{V}, s::Spherical) where {V <: AbstractVector} = convert(V, CartesianFromSpherical()(s))
+Base.convert(::Type{V}, c::Cylindrical) where {V <: AbstractVector} = convert(V, CartesianFromCylindrical()(c))
+Base.convert(::Type{V}, s::Spherical) where {V <: StaticVector} = convert(V, CartesianFromSpherical()(s))
+Base.convert(::Type{V}, c::Cylindrical) where {V <: StaticVector} = convert(V, CartesianFromCylindrical()(c))
 
 Base.convert(::Type{Spherical}, c::Cylindrical) = SphericalFromCylindrical()(c)
 Base.convert(::Type{Cylindrical}, s::Spherical) = CylindricalFromSpherical()(s)

--- a/src/core.jl
+++ b/src/core.jl
@@ -12,13 +12,13 @@ transformation on the correct data types by overloading the call method, and
 usually would have the corresponding inverse transformation defined by `Base.inv()`.
 Efficient compositions can optionally be defined by `compose()` (equivalently `∘`).
 """
-@compat abstract type Transformation end
+abstract type Transformation end
 
 """
 The `IdentityTransformation` is a singleton `Transformation` that returns the
 input unchanged, similar to `identity`.
 """
-immutable IdentityTransformation <: Transformation; end
+struct IdentityTransformation <: Transformation; end
 
 @inline (::IdentityTransformation)(x) = x
 
@@ -26,7 +26,7 @@ immutable IdentityTransformation <: Transformation; end
 A `ComposedTransformation` simply executes two transformations successively, and
 is the fallback output type of `compose()`.
 """
-immutable ComposedTransformation{T1 <: Transformation, T2 <: Transformation} <: Transformation
+struct ComposedTransformation{T1 <: Transformation, T2 <: Transformation} <: Transformation
     t1::T1
     t2::T2
 end

--- a/src/perspective.jl
+++ b/src/perspective.jl
@@ -18,7 +18,7 @@ example:
 
 (see also `cameramap`)
 """
-immutable PerspectiveMap <: Transformation
+struct PerspectiveMap <: Transformation
 end
 
 function (::PerspectiveMap)(v::AbstractVector)


### PR DESCRIPTION
I'm trying to update a bunch of packages for v0.7 compatibility. 

This package isn't seeing a lot of action relevant to v0.5.