### PR TITLE
atan2(y, x) -> atan(y, x)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 StaticArrays
 Rotations 0.3.0
-Compat 0.33
+Compat 0.69

--- a/src/coordinatesystems.jl
+++ b/src/coordinatesystems.jl
@@ -24,7 +24,7 @@ Base.show(io::IO, trans::CartesianFromPolar) = print(io, "CartesianFromPolar()")
 function (::PolarFromCartesian)(x::AbstractVector)
     length(x) == 2 || error("Polar transform takes a 2D coordinate")
 
-    Polar(sqrt(x[1]*x[1] + x[2]*x[2]), atan2(x[2], x[1]))
+    Polar(sqrt(x[1]*x[1] + x[2]*x[2]), atan(x[2], x[1]))
 end
 
 function transform_deriv(::PolarFromCartesian, x::AbstractVector)
@@ -114,7 +114,7 @@ Base.show(io::IO, trans::SphericalFromCylindrical) = print(io, "SphericalFromCyl
 function (::SphericalFromCartesian)(x::AbstractVector)
     length(x) == 3 || error("Spherical transform takes a 3D coordinate")
 
-    Spherical(sqrt(x[1]*x[1] + x[2]*x[2] + x[3]*x[3]), atan2(x[2],x[1]), atan(x[3]/sqrt(x[1]*x[1] + x[2]*x[2])))
+    Spherical(sqrt(x[1]*x[1] + x[2]*x[2] + x[3]*x[3]), atan(x[2],x[1]), atan(x[3]/sqrt(x[1]*x[1] + x[2]*x[2])))
 end
 function transform_deriv(::SphericalFromCartesian, x::AbstractVector)
     length(x) == 3 || error("Spherical transform takes a 3D coordinate")
@@ -151,7 +151,7 @@ transform_deriv_params(::CartesianFromSpherical, x::Spherical) = error("Cartesia
 function (::CylindricalFromCartesian)(x::AbstractVector)
     length(x) == 3 || error("Cylindrical transform takes a 3D coordinate")
 
-    Cylindrical(sqrt(x[1]*x[1] + x[2]*x[2]), atan2(x[2],x[1]), x[3])
+    Cylindrical(sqrt(x[1]*x[1] + x[2]*x[2]), atan(x[2],x[1]), x[3])
 end
 
 function transform_deriv(::CylindricalFromCartesian, x::AbstractVector)


### PR DESCRIPTION
Fixes the last deprecation warning on 0.7. 

Also, could you please tag a new release after this is merged so that we'll have an 0.7-compatible release? 