### PR TITLE
Reduce AffineMap application to Linear and Translation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 StaticArrays
 Rotations 0.3.0
 Compat 0.69

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -100,8 +100,10 @@ struct AffineMap{M, V} <: AbstractAffineMap
     translation::V
 end
 
-function (trans::AffineMap{M, V})(x) where {M, V}
-    trans.linear * x + trans.translation
+function (trans::AffineMap)(x)
+    l = LinearMap(trans.linear)
+    t = Translation(trans.translation)
+    t(l(x))
 end
 
 # Note: the expression `Tx - dT*Tx` will have large cancellation error for

--- a/test/affine.jl
+++ b/test/affine.jl
@@ -4,6 +4,18 @@ struct SquareMe <: Transformation; end
 (::SquareMe)(x) = x.^2
 CoordinateTransformations.transform_deriv(::SquareMe, x0) = Matrix(Diagonal(2*x0))
 
+struct Ray37
+    origin::Vector
+    direction::Vector
+end
+function (m::LinearMap)(r::Ray37)
+    Ray37(m(r.origin),
+          m(r.direction))
+end
+function (t::Translation)(r::Ray37)
+    Ray37(t(r.origin),
+          r.direction)
+end
 
 @testset "Common Transformations" begin
     @testset "AffineMap" begin
@@ -95,6 +107,18 @@ CoordinateTransformations.transform_deriv(::SquareMe, x0) = Matrix(Diagonal(2*x0
             @test c(origin) == origin
             @test c(zero(origin)) == [6,-6]
         end
+    end
+
+    @testset "application of AffineMap in terms of LinearMap and Translation" begin
+        origin = randn(3)
+        direction = randn(3)
+        linear = randn(3,3)
+        trans = randn(3)
+        r = Ray37(origin, direction)
+        expected = Ray37(linear*origin+trans, linear*direction)
+        result   = AffineMap(linear, trans)(r)
+        @test expected.origin ≈ result.origin
+        @test expected.direction ≈ result.direction
     end
 
 #=


### PR DESCRIPTION
This came up in #37. The performance regression discussed in #37 does not exist anymore in julia 0.7.
It is amazing, all intermediate objects (LinearMap, Translation...) are completly optimized out!
```julia
using CoordinateTransformations
using StaticArrays

function apply_lt(trans::AffineMap, x)
     l = LinearMap(trans.linear)
     t = Translation(trans.translation)
     t(l(x))
end

m = @SMatrix randn(3,3)
v = @SVector randn(3)
am = AffineMap(m,v)
@code_warntype apply_lt(am,v)
```

```
Body::SArray{Tuple{3},Float64,1,3}
│╻       getproperty5 1 ── %1  = (Base.getfield)(trans, :linear)::SArray{Tuple{3,3},Float64,2,9}
│╻       getproperty6 │    %2  = (Base.getfield)(trans, :translation)::SArray{Tuple{3},Float64,1,3}
│╻╷╷╷╷╷  LinearMap7 │    %3  = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││╻       *  │    %4  = (Base.getfield)(%3, 1, true)::Float64
│││╻       _mul  │    %5  = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││╻       macro expansion  │    %6  = (Base.getfield)(%5, 1, false)::Float64
│││││╻       *  │    %7  = (Base.mul_float)(%4, %6)::Float64
││││││╻       getproperty  │    %8  = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %9  = (Base.getfield)(%8, 4, true)::Float64
││││││╻       getproperty  │    %10 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %11 = (Base.getfield)(%10, 2, false)::Float64
│││││╻       *  │    %12 = (Base.mul_float)(%9, %11)::Float64
│││││╻       +  │    %13 = (Base.add_float)(%7, %12)::Float64
││││││╻       getproperty  │    %14 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %15 = (Base.getfield)(%14, 7, true)::Float64
││││││╻       getproperty  │    %16 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %17 = (Base.getfield)(%16, 3, false)::Float64
│││││╻       *  │    %18 = (Base.mul_float)(%15, %17)::Float64
│││││╻       +  │    %19 = (Base.add_float)(%13, %18)::Float64
││││││╻       getproperty  │    %20 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %21 = (Base.getfield)(%20, 2, true)::Float64
││││││╻       getproperty  │    %22 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %23 = (Base.getfield)(%22, 1, false)::Float64
│││││╻       *  │    %24 = (Base.mul_float)(%21, %23)::Float64
││││││╻       getproperty  │    %25 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %26 = (Base.getfield)(%25, 5, true)::Float64
││││││╻       getproperty  │    %27 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %28 = (Base.getfield)(%27, 2, false)::Float64
│││││╻       *  │    %29 = (Base.mul_float)(%26, %28)::Float64
│││││╻       +  │    %30 = (Base.add_float)(%24, %29)::Float64
││││││╻       getproperty  │    %31 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %32 = (Base.getfield)(%31, 8, true)::Float64
││││││╻       getproperty  │    %33 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %34 = (Base.getfield)(%33, 3, false)::Float64
│││││╻       *  │    %35 = (Base.mul_float)(%32, %34)::Float64
│││││╻       +  │    %36 = (Base.add_float)(%30, %35)::Float64
││││││╻       getproperty  │    %37 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %38 = (Base.getfield)(%37, 3, true)::Float64
││││││╻       getproperty  │    %39 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %40 = (Base.getfield)(%39, 1, false)::Float64
│││││╻       *  │    %41 = (Base.mul_float)(%38, %40)::Float64
││││││╻       getproperty  │    %42 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %43 = (Base.getfield)(%42, 6, true)::Float64
││││││╻       getproperty  │    %44 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %45 = (Base.getfield)(%44, 2, false)::Float64
│││││╻       *  │    %46 = (Base.mul_float)(%43, %45)::Float64
│││││╻       +  │    %47 = (Base.add_float)(%41, %46)::Float64
││││││╻       getproperty  │    %48 = (Base.getfield)(%1, :data)::NTuple{9,Float64}
││││││╻       getindex  │    %49 = (Base.getfield)(%48, 9, true)::Float64
││││││╻       getproperty  │    %50 = (Base.getfield)(x, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %51 = (Base.getfield)(%50, 3, false)::Float64
│││││╻       *  │    %52 = (Base.mul_float)(%49, %51)::Float64
│││││╻       +  │    %53 = (Base.add_float)(%47, %52)::Float64
│││││     └───       goto #3
│││││     2 ──       $(Expr(:unreachable))
│││       3 ┄─       goto #4
││        4 ──       goto #5
││╻╷╷╷╷╷  +  5 ── %58 = (Base.getfield)(%2, :data)::Tuple{Float64,Float64,Float64}
│││╻       map  │    %59 = (Base.getfield)(%58, 1, false)::Float64
││││╻       _map  │    %60 = (Base.add_float)(%19, %59)::Float64
│││││╻       macro expansion  │    %61 = (Base.getfield)(%2, :data)::Tuple{Float64,Float64,Float64}
││││││╻       getindex  │    %62 = (Base.getfield)(%61, 2, false)::Float64
││││││╻       +  │    %63 = (Base.add_float)(%36, %62)::Float64
│││││││╻       getproperty  │    %64 = (Base.getfield)(%2, :data)::Tuple{Float64,Float64,Float64}
│││││││╻       getindex  │    %65 = (Base.getfield)(%64, 3, false)::Float64
││││││╻       +  │    %66 = (Base.add_float)(%53, %65)::Float64
││││││    │    %67 = (StaticArrays.tuple)(%60, %63, %66)::Tuple{Float64,Float64,Float64}
││││││╻       Type  │    %68 = %new(SArray{Tuple{3},Float64,1,3}, %67)::SArray{Tuple{3},Float64,1,3}
││││││    └───       goto #7
││││││    6 ──       $(Expr(:unreachable))
││││      7 ┄─       goto #8
│││       8 ──       goto #9
││        9 ──       goto #10
│         10 ─       return %68
```